### PR TITLE
Add PhoneNumber::isPossibleNumber() for more lenient validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,22 @@ catch (PhoneNumberParseException $e) {
 }
 ```
 
-In most cases, it is recommended to perform an extra step of validation with `isValidNumber()`:
+In most cases, it is recommended to perform an extra step of validation with `isValidNumber()` or `isPossibleNumber()`:
 
 ```php
-if (! $number->isValidNumber()) {
-    // ...
+if (! $number->isPossibleNumber()) {
+    // a more lenient and faster check than `isValidNumber()`
 }
+
+if (! $number->isValidNumber()) {
+    // strict check relying on up-to-date metadata library
+}
+
 ```
 
 As a rule of thumb, do the following:
 
-- When the number comes from user input, do a full validation: `parse()` and catch `PhoneNumberParseException`, then call `isValidNumber()` if no exception occurred;
+- When the number comes from user input, do a full validation: `parse()` and catch `PhoneNumberParseException`, then call `isValidNumber()` (or `isPossibleNumber()` for a more lenient check) if no exception occurred;
 - When the number is later retrieved from your database, and has been validated before, you can just perform a blind `parse()`.
 
 ### Formatting a number

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -115,6 +115,18 @@ class PhoneNumber
     }
 
     /**
+     * Returns whether this phone number is a possible number.
+     *
+     * Note this provides a more lenient and faster check than `isValidNumber()`.
+     *
+     * @return bool
+     */
+    public function isPossibleNumber() : bool
+    {
+        return PhoneNumberUtil::getInstance()->isPossibleNumber($this->phoneNumber);
+    }
+
+    /**
      * Returns whether this phone number matches a valid pattern.
      *
      * Note this doesn't verify the number is actually in use,

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -257,7 +257,28 @@ class PhoneNumberTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsValidNumber
+     * @dataProvider providerValidNumbers
+     * @dataProvider providerPossibleButNotValidNumbers
+     *
+     * @param string $phoneNumber
+     */
+    public function testIsPossibleNumber($phoneNumber)
+    {
+        $this->assertTrue(PhoneNumber::parse($phoneNumber)->isPossibleNumber());
+    }
+
+    /**
+     * @dataProvider providerNotPossibleNumbers
+     *
+     * @param string $phoneNumber
+     */
+    public function testIsNotPossibleNumber($phoneNumber)
+    {
+        $this->assertFalse(PhoneNumber::parse($phoneNumber)->isPossibleNumber());
+    }
+
+    /**
+     * @dataProvider providerValidNumbers
      *
      * @param string $phoneNumber
      */
@@ -267,9 +288,20 @@ class PhoneNumberTest extends TestCase
     }
 
     /**
+     * @dataProvider providerNotPossibleNumbers
+     * @dataProvider providerPossibleButNotValidNumbers
+     *
+     * @param string $phoneNumber
+     */
+    public function testIsNotValidNumber($phoneNumber)
+    {
+        $this->assertFalse(PhoneNumber::parse($phoneNumber)->isValidNumber());
+    }
+
+    /**
      * @return array
      */
-    public function providerIsValidNumber()
+    public function providerValidNumbers()
     {
         return [
             [self::US_NUMBER],
@@ -282,19 +314,9 @@ class PhoneNumberTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsNotValidNumber
-     *
-     * @param string $phoneNumber
-     */
-    public function testIsNotValidNumber($phoneNumber)
-    {
-        $this->assertFalse(PhoneNumber::parse($phoneNumber)->isValidNumber());
-    }
-
-    /**
      * @return array
      */
-    public function providerIsNotValidNumber()
+    public function providerPossibleButNotValidNumbers()
     {
         return [
             [self::US_LOCAL_NUMBER],
@@ -302,8 +324,18 @@ class PhoneNumberTest extends TestCase
             ['+44791234567'],
             ['+491234'],
             ['+643316005'],
-            ['+39232366'],
-            [self::INTERNATIONAL_TOLL_FREE_TOO_LONG]
+            ['+39232366']
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function providerNotPossibleNumbers()
+    {
+        return [
+            [self::INTERNATIONAL_TOLL_FREE_TOO_LONG],
+            ['+4912']
         ];
     }
 


### PR DESCRIPTION
You don't always want to do a full strict validation of phone number (this relies on up-to-date metadata), but still want to do "some" validation. That's where `isPossibleNumber()` comes in handy - it only checks the lenght of the number - these rules (hopefully) do not change very often.

More details: https://github.com/giggsey/libphonenumber-for-php/blob/master/docs/PhoneNumberUtil.md#ispossiblenumber