### PR TITLE
Actualize links to PHP classes from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ As a rule of thumb, do the following:
 
 #### Basic formatting
 
-You can use `format()` with constants from the [PhoneNumberFormat](https://github.com/brick/phonenumber/blob/0.4.0/src/PhoneNumberFormat.php) class:
+You can use `format()` with constants from the [PhoneNumberFormat](https://github.com/brick/phonenumber/blob/master/src/PhoneNumberFormat.php) class:
 
 ```php
 $number = PhoneNumber::parse('+41446681800');
@@ -118,7 +118,7 @@ $number->formatForCallingFrom('US'); // 011 44 7123 456789
 ### Number types
 
 In certain cases, it is possible to know the type of a phone number (fixed line, mobile phone, etc.), using
-the `getNumberType()` method, which returns a constant from the [PhoneNumberType](https://github.com/brick/phonenumber/blob/0.4.0/src/PhoneNumberType.php) class:
+the `getNumberType()` method, which returns a constant from the [PhoneNumberType](https://github.com/brick/phonenumber/blob/master/src/PhoneNumberType.php) class:
 
 ```php
 PhoneNumber::parse('+336123456789')->getNumberType(); // PhoneNumberType::MOBILE

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ As a rule of thumb, do the following:
 
 #### Basic formatting
 
-You can use `format()` with constants from the [PhoneNumberFormat](https://github.com/brick/phonenumber/blob/0.2.0/src/PhoneNumberFormat.php) class:
+You can use `format()` with constants from the [PhoneNumberFormat](https://github.com/brick/phonenumber/blob/0.4.0/src/PhoneNumberFormat.php) class:
 
 ```php
 $number = PhoneNumber::parse('+41446681800');
@@ -118,7 +118,7 @@ $number->formatForCallingFrom('US'); // 011 44 7123 456789
 ### Number types
 
 In certain cases, it is possible to know the type of a phone number (fixed line, mobile phone, etc.), using
-the `getNumberType()` method, which returns a constant from the [PhoneNumberType](https://github.com/brick/phonenumber/blob/0.2.0/src/PhoneNumberType.php) class:
+the `getNumberType()` method, which returns a constant from the [PhoneNumberType](https://github.com/brick/phonenumber/blob/0.4.0/src/PhoneNumberType.php) class:
 
 ```php
 PhoneNumber::parse('+336123456789')->getNumberType(); // PhoneNumberType::MOBILE


### PR DESCRIPTION
Just an actual pin to the latest version.

Can't be sure, how to automate this process to avoid manual work.
UPD: it can be avoided with links containing the 'master' branch version. It won't be stable in time, but helps to avoid manual work. Applied this way as of @xJuvi suggestion