### PR TITLE
added failing German mobile number to tests

### DIFF
--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -460,6 +460,9 @@ class PhoneNumberTest extends TestCase
             ['030 123456', self::DE_NUMBER, PhoneNumberFormat::NATIONAL],
 
             ['04134 1234', '+4941341234', PhoneNumberFormat::NATIONAL],
+            
+            // DE mobile
+            ['01520 123123', '+491520123123', PhoneNumberFormat::NATIONAL],
 
             // IT
             ['02 3661 8300', self::IT_NUMBER, PhoneNumberFormat::NATIONAL],


### PR DESCRIPTION
Formatting this mobile number will fail right now as the leading zero is missing in the national format.
This is just an example that should proof the issue #12 can not be fixed by the proposal there in case it is a certain mobile carrier prefix and not a fixed landline.

The error in formatting comes from the underlying library (https://libphonenumber.appspot.com/phonenumberparser?number=%2B491520123123&country=DE&geocodingLocale=de-DE). I filed an issue there but as soon as it get fixed there, adding a test here makes sense to me.

https://issuetracker.google.com/issues/247105388